### PR TITLE
Allow recreating full state from DOM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "compose-area"
+description = "A compose area with support for Emoji, written with Rust + Webassembly."
 version = "0.1.0"
 authors = ["Danilo Bargen <danilo.bargen@threema.ch>"]
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ emoji), implemented on top of a content editable div.
 
 If you've ever done any cross-browser editor implementation using
 content-editable elements, then you know that content-editable elements are
-terrible. They behave differently in every browser and the transformations
-resulting from input events are not well-defined. Please read [this blogpost by
-Medium Engineering](https://medium.engineering/why-contenteditable-is-terrible-122d8a40e480)
+terrible. They [behave differently](https://www.dhs.state.il.us/accessibility/tests/contenteditabletest.html)
+in every browser and the transformations resulting from input events are not
+well-defined. Please read [this blogpost by Medium
+Engineering](https://medium.engineering/why-contenteditable-is-terrible-122d8a40e480)
 for some more background information.
 
 This project uses DOM event listeners, WebAssembly (through Rust) and a virtual

--- a/README.md
+++ b/README.md
@@ -39,8 +39,13 @@ DOM to implement a text editor that reacts predictably to input events:
     matches the new state. By applying those patches to the DOM, we can sync
     the two states.
 
-This gives us reliable, well-defined and testable behavior for a simple text
-editor.
+This gives us mostly reliable, well-defined and testable behavior for a simple
+text editor.
+
+Unfortunately there are situations where input events are not clearly defined
+by web standards. For example when using an IME to input Japanese text, or when
+using autocompletion on a touch device. In those cases, we simply re-parse the
+DOM and convert it back into the internal state representation.
 
 
 ## Setup

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,4 +311,11 @@ impl ComposeArea {
         let wrapper = self.get_wrapper();
         wrapper.set_inner_html("");
     }
+
+    /// Reload internal state from DOM.
+    pub fn reload_from_dom(&mut self) {
+        debug!("WASM: reload_from_dom");
+        let wrapper = self.get_wrapper();
+        self.state = State::from_dom(&wrapper);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, feature(proc_macro_hygiene))]
+
 #![deny(clippy::all)]
 #![warn(clippy::pedantic)]
 #![allow(clippy::non_ascii_literal, clippy::single_match_else, clippy::if_not_else,

--- a/src/state.rs
+++ b/src/state.rs
@@ -5,6 +5,7 @@ use wasm_bindgen::JsCast;
 use web_sys::{self, Element as DomElement, Node as DomNode};
 
 use crate::keys::Key;
+use crate::utils::{CaretPosition, get_caret_position};
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Node {
@@ -95,10 +96,21 @@ impl State {
             nodes.pop();
         }
 
-        Self {
-            nodes,
-            caret_start: 0,  // TODO: Actual pos
-            caret_end: 0,
+        // Determine caret position
+        let pos: CaretPosition = get_caret_position(element);
+        if pos.success {
+            assert!(pos.start <= pos.end);
+            Self {
+                nodes,
+                caret_start: pos.start as usize,
+                caret_end: pos.end as usize,
+            }
+        } else {
+            Self {
+                nodes,
+                caret_start: 0,
+                caret_end: 0,
+            }
         }
     }
 

--- a/www/index.html
+++ b/www/index.html
@@ -31,6 +31,9 @@
             font-size: 0.8em;
             color: #777;
         }
+        #log {
+            font-size: 0.5em;
+        }
     </style>
   </head>
   <body>

--- a/www/index.html
+++ b/www/index.html
@@ -48,6 +48,7 @@
         <img height="32" alt="🤦‍♀️" width="32" src="https://abs.twimg.com/emoji/v2/72x72/1f926-200d-2640-fe0f.png">
       </button>
     </div>
+    <div id="log"></div>
     <p id="version">[[VERSION]]</p>
     <p>Links: <a href="benchmark.html">Benchmarks</a> | <a href="https://github.com/threema-ch/compose-area">GitHub</a></p>
     <script src="./bootstrap.demo.bundle.js"></script>

--- a/www/index.js
+++ b/www/index.js
@@ -51,6 +51,8 @@ wrapper.addEventListener('compositionupdate', (e) => {
 wrapper.addEventListener('compositionend', (e) => {
     log('compositionend:', e);
     compositionState.composing = false;
+    log('--reload_from_dom');
+    composeArea.reload_from_dom();
 });
 wrapper.addEventListener('change', (e) => {
     log('change:', e);

--- a/www/index.js
+++ b/www/index.js
@@ -63,7 +63,7 @@ wrapper.addEventListener('keydown', (e) => {
         // Ignore key events while composing
         e.preventDefault();
         return;
-    } else if (!e.ctrlKey && !e.altKey && !e.metaKey) {
+    } else if (!e.ctrlKey && !e.altKey && !e.metaKey && e.key !== 'Unidentified') {
         log('--process_key: ' + e.key);
         const preventDefault = composeArea.process_key(e.key);
         if (preventDefault) {

--- a/www/index.js
+++ b/www/index.js
@@ -5,10 +5,21 @@ window.wasm = wasm;
 
 // Initialize compose area
 const composeArea = wasm.bind_to('wrapper');
+window.composeArea = composeArea;
 
 // Add event listeners
 
 const wrapper = document.getElementById('wrapper');
+const logDiv = document.getElementById('log');
+
+function log() {
+    console.log(...arguments);
+    let text = '';
+    for (const arg of arguments) {
+        text += arg;
+    }
+    logDiv.innerHTML += `${text}<br>`;
+}
 
 /**
  * When the selection changes, update the caret position.
@@ -17,7 +28,7 @@ const wrapper = document.getElementById('wrapper');
  * wrapper itself.
  */
 document.addEventListener('selectionchange', (e) => {
-    console.log('selectionchange', e);
+    log('selectionchange', e);
     composeArea.update_caret_position();
 });
 
@@ -30,23 +41,23 @@ const compositionState = {
  * On keydown, process the key.
  */
 wrapper.addEventListener('compositionstart', (e) => {
-    console.log('compositionstart:', e);
+    log('compositionstart:', e);
     compositionState.composing = true;
 });
 wrapper.addEventListener('compositionupdate', (e) => {
-    console.log('compositionupdate:', e);
+    log('compositionupdate:', e);
 });
 wrapper.addEventListener('compositionend', (e) => {
-    console.log('compositionend:', e);
+    log('compositionend:', e);
     compositionState.composing = false;
 
     composeArea.insert_text(e.data);
 });
 wrapper.addEventListener('change', (e) => {
-    console.log('change:', e);
+    log('change:', e);
 });
 wrapper.addEventListener('keydown', (e) => {
-    console.log('keydown:', e);
+    log('keydown:', e);
     if (compositionState.composing) {
         // Ignore key events while composing
         e.preventDefault();
@@ -59,10 +70,21 @@ wrapper.addEventListener('keydown', (e) => {
     }
 });
 wrapper.addEventListener('keyup', (e) => {
-    console.log('keyup:', e);
+    log('keyup:', e);
 });
 wrapper.addEventListener('keypress', (e) => {
-    console.log('keypress:', e);
+    log('keypress:', e);
+});
+
+/**
+ * This event is fired when an edit event takes place for which we cannot
+ * capture the input event.
+ *
+ * When this happens, reload the internal state from DOM.
+ */
+wrapper.addEventListener('input', (e) => {
+    log('input:', e.inputType, e);
+    composeArea.reload_from_dom();
 });
 
 /**
@@ -72,7 +94,7 @@ wrapper.addEventListener('keypress', (e) => {
  * removed from the input field.
  */
 wrapper.addEventListener('cut', (e) => {
-    console.log('cut', e);
+    log('cut', e);
     composeArea.remove_selection(false);
 });
 
@@ -83,7 +105,7 @@ wrapper.addEventListener('cut', (e) => {
  * selection and update the DOM.
  */
 wrapper.addEventListener('paste', (e) => {
-    console.log('paste', e);
+    log('paste', e);
     const clipboardData = e.clipboardData.getData('text/plain');
     if (clipboardData) {
         composeArea.insert_text(clipboardData);
@@ -94,6 +116,7 @@ wrapper.addEventListener('paste', (e) => {
 // Emoji handling
 
 function insertEmoji(e) {
+    log('insertEmoji');
     const img = e.target.nodeName === 'IMG' ? e.target : e.target.children[0];
     composeArea.insert_image(img.src, img.alt, 'emoji');
 }

--- a/www/index.js
+++ b/www/index.js
@@ -29,6 +29,7 @@ function log() {
  */
 document.addEventListener('selectionchange', (e) => {
     log('selectionchange', e);
+    log('--update_caret_position');
     composeArea.update_caret_position();
 });
 
@@ -50,8 +51,6 @@ wrapper.addEventListener('compositionupdate', (e) => {
 wrapper.addEventListener('compositionend', (e) => {
     log('compositionend:', e);
     compositionState.composing = false;
-
-    composeArea.insert_text(e.data);
 });
 wrapper.addEventListener('change', (e) => {
     log('change:', e);
@@ -63,6 +62,7 @@ wrapper.addEventListener('keydown', (e) => {
         e.preventDefault();
         return;
     } else if (!e.ctrlKey && !e.altKey && !e.metaKey) {
+        log('--process_key: ' + e.key);
         const preventDefault = composeArea.process_key(e.key);
         if (preventDefault) {
             e.preventDefault();
@@ -85,6 +85,7 @@ wrapper.addEventListener('keypress', (e) => {
 wrapper.addEventListener('input', (e) => {
     log('input:', e.inputType, e);
     if (!compositionState.composing) {
+        log('--reload_from_dom');
         composeArea.reload_from_dom();
     }
 });
@@ -97,6 +98,7 @@ wrapper.addEventListener('input', (e) => {
  */
 wrapper.addEventListener('cut', (e) => {
     log('cut', e);
+    log('--remove_selection');
     composeArea.remove_selection(false);
 });
 
@@ -110,6 +112,7 @@ wrapper.addEventListener('paste', (e) => {
     log('paste', e);
     const clipboardData = e.clipboardData.getData('text/plain');
     if (clipboardData) {
+        log('--insert_text: ' + clipboardData);
         composeArea.insert_text(clipboardData);
         e.preventDefault();
     }
@@ -120,6 +123,7 @@ wrapper.addEventListener('paste', (e) => {
 function insertEmoji(e) {
     log('insertEmoji');
     const img = e.target.nodeName === 'IMG' ? e.target : e.target.children[0];
+    log('--insert_image');
     composeArea.insert_image(img.src, img.alt, 'emoji');
 }
 document.getElementById('tongue').addEventListener('click', insertEmoji);

--- a/www/index.js
+++ b/www/index.js
@@ -84,7 +84,9 @@ wrapper.addEventListener('keypress', (e) => {
  */
 wrapper.addEventListener('input', (e) => {
     log('input:', e.inputType, e);
-    composeArea.reload_from_dom();
+    if (!compositionState.composing) {
+        composeArea.reload_from_dom();
+    }
 });
 
 /**

--- a/www/index.js
+++ b/www/index.js
@@ -12,14 +12,6 @@ window.composeArea = composeArea;
 const wrapper = document.getElementById('wrapper');
 const logDiv = document.getElementById('log');
 
-const state = {
-    // True when a composition is in progress
-    composing: false,
-
-    // Re-parse the div for every input event.
-    aggressiveMode: false,
-};
-
 function log() {
     console.log(...arguments);
     let text = '';
@@ -41,50 +33,41 @@ document.addEventListener('selectionchange', (e) => {
     composeArea.update_caret_position();
 });
 
+// Composition state
+const compositionState = {
+    composing: false,
+};
+
 /**
  * On keydown, process the key.
  */
 wrapper.addEventListener('compositionstart', (e) => {
     log('compositionstart:', e);
-    state.composing = true;
-
-    // When an Firefox on Android user types "a" and presses enter, this
-    // results in *both* a composition event and a key event. Unfortunately we
-    // can't really know the difference between a key event following a
-    // composition, and a regular key event. Thus, we enable aggressive mode
-    // when compositions are used.
-    state.aggressiveMode = true;
+    compositionState.composing = true;
 });
 wrapper.addEventListener('compositionupdate', (e) => {
     log('compositionupdate:', e);
 });
 wrapper.addEventListener('compositionend', (e) => {
-    log('compositionend:', e.data);
-    state.composing = false;
+    log('compositionend:', e);
+    compositionState.composing = false;
 });
 wrapper.addEventListener('change', (e) => {
     log('change:', e);
 });
 wrapper.addEventListener('keydown', (e) => {
-    if (state.composing) {
+    log('keydown:', e);
+    if (compositionState.composing) {
         // Ignore key events while composing
-        log('keydown[suppressed]:', e);
         e.preventDefault();
         return;
-    } else if (state.aggressiveMode) {
-        // Process keys as usual, handle them with the input event.
-        log('keydown[aggressive]:', e);
-        return;
     } else if (!e.ctrlKey && !e.altKey && !e.metaKey) {
-        log('keydown[process]:', e);
         log('--process_key: ' + e.key);
         const preventDefault = composeArea.process_key(e.key);
         if (preventDefault) {
             e.preventDefault();
         }
-        return;
     }
-    log('keydown[default]:', e);
 });
 wrapper.addEventListener('keyup', (e) => {
     log('keyup:', e);
@@ -101,7 +84,7 @@ wrapper.addEventListener('keypress', (e) => {
  */
 wrapper.addEventListener('input', (e) => {
     log('input:', e.inputType, e);
-    if (!state.composing) {
+    if (!compositionState.composing) {
         log('--reload_from_dom');
         composeArea.reload_from_dom();
     }

--- a/www/prod.js
+++ b/www/prod.js
@@ -1,0 +1,9 @@
+var express = require('express');
+var app = express();
+
+// Set the MIME type explicitly
+express.static.mime.define({'application/wasm': ['wasm']});
+
+app.use(express.static('./dist'));
+
+app.listen(9999);


### PR DESCRIPTION
When there is a change to the compose area for which we cannot capture the input (e.g. deleting on Android) we have to rebuild the state from DOM.