### PR TITLE
Fix bug in add_range_at

### DIFF
--- a/selenium/tests.ts
+++ b/selenium/tests.ts
@@ -178,6 +178,29 @@ async function replaceSelectedTextAndEmoji(driver: WebDriver) {
 }
 
 /**
+ * Cursor position after replacing emoji.
+ */
+async function replaceEmojiWithText(driver: WebDriver) {
+    await driver.sleep(100); // Wait for compose area init
+
+    const wrapperElement = await driver.findElement(wrapper);
+    const emoji = await driver.findElement(emojiTongue);
+
+    await wrapperElement.click();
+
+    await wrapperElement.sendKeys('a');
+    emoji.click();
+    await wrapperElement.sendKeys('b');
+    await wrapperElement.sendKeys(Key.ARROW_LEFT);
+    await wrapperElement.sendKeys(Key.SHIFT + Key.ARROW_LEFT);
+    await wrapperElement.sendKeys('A');
+    await wrapperElement.sendKeys('B');
+
+    const text = await extractText(driver);
+    expect(text).to.equal('aABb');
+}
+
+/**
  * Replace all text.
  */
 async function replaceAllText(driver: WebDriver) {
@@ -256,6 +279,7 @@ export const TESTS: Array<[string, Testfunc]> = [
     ['Replace selected text with text', replaceSelectedTextWithText],
     ['Replace selected text with emoji', replaceSelectedTextWithEmoji],
     ['Replace selected text and emoji', replaceSelectedTextAndEmoji],
+    ['Replace emoji with text', replaceEmojiWithText],
     // Doesn't work in Firefox. Disabled until
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1529540 is resolved.
     //['Replace all text', replaceAllText],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,15 +127,15 @@ fn add_range_at(pos: &Position) {
     match pos {
         Position::After(node) => {
             range.set_start_after(node).expect("Could not set_start_after");
-            range.collapse();
+            range.set_end_after(node).expect("Could not set_end_after");
         }
         Position::Offset(node, 0) => {
-            range.set_start_before(node).expect("Could not set_range_before");
-            range.collapse();
+            range.set_start_before(node).expect("Could not set_start_before");
+            range.set_end_before(node).expect("Could not set_end_before");
         }
         Position::Offset(node, offset) => {
             range.set_start(node, *offset).expect("Could not set_start");
-            range.collapse();
+            range.set_end(node, *offset).expect("Could not set_end");
         }
     }
 


### PR DESCRIPTION
The `collapse()` method does not work as intended and the parameter is
experimental. Instead, use explicit end positions.