### PR TITLE
Fix undo history

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ features = [
     "Document",
     "DomTokenList",
     "Element",
+    "HtmlDocument",
     "HtmlElement",
     "HtmlImageElement",
     "Node",

--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ const ca = await import('@threema/compose-area');
 
 ### Initialization
 
+This library requires a wrapper element with `white-space` set to `pre` or
+`pre-wrap` in order to work properly.
+
+```html
+<div id="wrapper" style="white-space: pre-wrap;"></div>
+```
+
 First, bind to the wrapper element:
 
 ```js

--- a/README.md
+++ b/README.md
@@ -102,11 +102,17 @@ area.insert_image("emoji.jpg", "😀", "emoji");
 area.insert_text("hello");
 ```
 
-You can also insert a DOM node directly:
+You can also insert HTML or a DOM node directly:
 
 ```js
+area.insert_html("<div></div>");
 area.insert_node(document.createElement("span"));
 ```
+
+*(Note: Due to browser limitations, inserting a node directly will not result
+in a new entry in the browser's internal undo stack. This means that the node
+insertion cannot be undone using Ctrl+Z. If you need that, use `insert_html`
+instead.)*
 
 The `insert_image` method returns a reference to the inserted element, so that
 you can set custom attributes on it.

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -3,8 +3,6 @@
 use wasm_bindgen::JsCast;
 use web_sys::{Node, Range, Text};
 
-use crate::utils::is_character_data_node;
-
 /// A position relative to a node.
 #[derive(Debug)]
 pub enum Position<'a> {
@@ -54,11 +52,7 @@ pub fn set_selection_range(start: &Position, end: Option<&Position>) -> Option<R
             range.set_start_before(node).expect("Could not set_start_before");
         }
         Position::Offset(node, offset) => {
-            if is_character_data_node(&node) {
-                range.set_start(node, *offset).expect("Could not set_start");
-            } else {
-                range.set_start_after(node).expect("Could not set_start_after");
-            }
+            range.set_start(node, *offset).expect("Could not set_start");
         }
     }
 
@@ -71,11 +65,7 @@ pub fn set_selection_range(start: &Position, end: Option<&Position>) -> Option<R
             range.set_end_before(node).expect("Could not set_end_before");
         }
         Some(Position::Offset(node, offset)) => {
-            if is_character_data_node(&node) {
-                range.set_end(node, *offset).expect("Could not set_start");
-            } else {
-                range.set_end_after(node).expect("Could not set_end_after");
-            }
+            range.set_end(node, *offset).expect("Could not set_start");
         }
         None => range.collapse_with_to_start(true),
     }

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -1,13 +1,12 @@
 /// Everything related to the caret position and DOM selection ranges.
 
 use wasm_bindgen::JsCast;
-use web_sys::{Node, Range, Text};
+use web_sys::{Node, Selection, Range, Text};
 
 /// A position relative to a node.
 #[derive(Debug)]
 pub enum Position<'a> {
     /// Caret position is before the selected node.
-    #[allow(dead_code)]  // Needed in tests
     Before(&'a Node),
 
     /// Caret position is after the selected node.
@@ -70,6 +69,13 @@ pub fn set_selection_range(start: &Position, end: Option<&Position>) -> Option<R
         None => range.collapse_with_to_start(true),
     }
 
+    activate_selection_range(&selection, &range);
+    Some(range)
+}
+
+/// Activate the specified selection range in the DOM. Remove all previous
+/// ranges.
+pub fn activate_selection_range(selection: &Selection, range: &Range) {
     // Note: In theory we don't need to re-add the range to the document if
     //       it's already there. Unfortunately, Safari is not spec-compliant
     //       and returns a copy of the range instead of a reference when using
@@ -79,8 +85,6 @@ pub fn set_selection_range(start: &Position, end: Option<&Position>) -> Option<R
     //       See https://bugs.webkit.org/show_bug.cgi?id=145212
     selection.remove_all_ranges().unwrap();
     selection.add_range(&range).expect("Could not add range");
-
-    Some(range)
 }
 
 #[cfg(test)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,6 @@
 use cfg_if::cfg_if;
 use log::Level;
-use wasm_bindgen::JsCast;
-use web_sys::{CharacterData, Node, Element};
+use web_sys::{Node, Element};
 
 cfg_if! {
     // When the `console_error_panic_hook` feature is enabled, we can call the
@@ -32,12 +31,6 @@ cfg_if! {
     } else {
         pub fn init_log(_level: Level) {}
     }
-}
-
-/// Return whether the node is a character data node.
-#[inline]
-pub(crate) fn is_character_data_node(node: &Node) -> bool {
-    node.is_instance_of::<CharacterData>()
 }
 
 /// Return the last child node of the specified parent element (or `None`).


### PR DESCRIPTION
Unfortunately DOM manipulations that don't use `document.execCommand` aren't added to the undo stack. So we have to resort to inserting HTML strings using the `insertHTML` command.

This increases the benchmark time a bit:

- Insert text: 260 us -> 320 us
- Insert image: 390 us -> 910 us

Still below 1 ms though, so all is fine. The code is considerably more ugly though :slightly_frowning_face: 

Fixes #42.