### PR TITLE
Add is_empty method

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,28 @@ To extract the text from the area, there's also a method:
 area.get_text();
 ```
 
+By default, leading and trailing white-space is trimmed from the text. To
+disable this, pass `true` to the `get_text` method.
+
+```js
+area.get_text(true /* no_trim */);
+```
+
 ### Other helpers
+
+To test whether the compose area is empty:
+
+```js
+area.is_empty();
+```
+
+By default, if the compose area contains purely white-space, this method still
+considers the compose area to be empty. If you want a compose area containing
+white-space to be treated as non-empty, pass `true` to the `is_empty` method.
+
+```js
+area.is_empty(true /* no_trim */);
+```
 
 To focus the compose area programmatically:
 

--- a/selenium/tests.ts
+++ b/selenium/tests.ts
@@ -31,6 +31,13 @@ async function extractText(driver: WebDriver): Promise<string> {
     return text;
 }
 
+async function isEmpty(driver: WebDriver): Promise<boolean> {
+    const isEmpty: boolean = await driver.executeScript(`
+        return window.composeArea.is_empty();
+    `);
+    return isEmpty;
+}
+
 async function clearSelectionRange(driver: WebDriver): Promise<void> {
     const clearBtn = await driver.findElement(By.id('clearselection'));
     await clearBtn.click();
@@ -52,6 +59,23 @@ async function skipInBrowser(driver: WebDriver, browser: string): Promise<boolea
 async function wrapperFound(driver: WebDriver) {
     const wrapperElement = await driver.findElement(wrapper);
     expect(wrapperElement).to.exist;
+}
+
+/**
+ * Text insertion and the `is_empty` method should work as intended.
+ */
+async function insertText(driver: WebDriver) {
+    await driver.sleep(100); // Wait for compose area init
+    const wrapperElement = await driver.findElement(wrapper);
+
+    expect(await extractText(driver)).to.equal('');
+    expect(await isEmpty(driver)).to.be.true;
+
+    await wrapperElement.click();
+    await wrapperElement.sendKeys('abcde');
+
+    expect(await extractText(driver)).to.equal('abcde');
+    expect(await isEmpty(driver)).to.be.false;
 }
 
 /**
@@ -378,6 +402,7 @@ async function noDuplicatedNewlines2(driver: WebDriver) {
 
 export const TESTS: Array<[string, Testfunc]> = [
     ['Make sure that the wrapper element can be found', wrapperFound],
+    ['Insert text', insertText],
     ['Insert three emoji', insertThreeEmoji],
     ['Insert text between emoji', insertTextBetweenEmoji],
     ['Replace selected text with text', replaceSelectedTextWithText],

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -102,7 +102,7 @@ fn visit_child_nodes(parent_node: &Element, text: &mut String) {
 mod tests {
     use super::*;
 
-    use wasm_bindgen_test::*;
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
 
     wasm_bindgen_test_configure!(run_in_browser);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -483,6 +483,20 @@ impl ComposeArea {
         extract_text(&self.wrapper, no_trim.unwrap_or(false))
     }
 
+    /// Return whether the compose area is empty.
+    ///
+    /// Note: Right now this is a convenience wrapper around
+    /// `get_text(no_trim).length === 0`, but it might get optimized in the
+    /// future.
+    ///
+    /// Args:
+    /// - `no_trim`: If set to `true`, don't trim leading / trailing whitespace
+    ///   from returned text. Default: `false`.
+    pub fn is_empty(&self, no_trim: Option<bool>) -> bool {
+        debug!("[compose_area] is_empty");
+        extract_text(&self.wrapper, no_trim.unwrap_or(false)).is_empty()
+    }
+
     /// Focus the compose area.
     pub fn focus(&self) {
         debug!("[compose_area] focus");


### PR DESCRIPTION
Right now this is a convenience feature, but it could be optimized by
doing early-return as soon as some input is found in the DOM tree.